### PR TITLE
Remove --method arg, since it's not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ It's a equivalent of this commands:
 ```
 $ bundle exec hanami generate action [app] [controller]#index
 $ bundle exec hanami generate action [app] [controller]#new
-$ bundle exec hanami generate action [app] [controller]#create --method=post
+$ bundle exec hanami generate action [app] [controller]#create
 $ bundle exec hanami generate action [app] [controller]#show
 $ bundle exec hanami generate action [app] [controller]#edit
-$ bundle exec hanami generate action [app] [controller]#update --method=put
-$ bundle exec hanami generate action [app] [controller]#delete --method=destroy
+$ bundle exec hanami generate action [app] [controller]#update
+$ bundle exec hanami generate action [app] [controller]#delete
 ```
 
-### Supported command
+### Supported commands
 #### `--except`
 Just call:
 ```
@@ -45,7 +45,7 @@ It's a equivalent of this commands:
 ```
 $ bundle exec hanami generate action [app] [controller]#index
 $ bundle exec hanami generate action [app] [controller]#new
-$ bundle exec hanami generate action [app] [controller]#create --method=post
+$ bundle exec hanami generate action [app] [controller]#create
 ```
 
 #### `--only`


### PR DESCRIPTION
See: https://github.com/hanami/hanami/commit/46f6ffa5cf71741f5d2e84205dfe7a0a21db31cf

You can also get rid of a lot of code in the main file here: https://github.com/davydovanton/hanami-scaffold/blob/master/lib/hanami.rb#L11 since `hanami` will handle picking the correct HTTP verb for you :)
